### PR TITLE
implemented terminal_write_int

### DIFF
--- a/src/io/terminal.cpp
+++ b/src/io/terminal.cpp
@@ -5,7 +5,7 @@
 
 static const size_t VGA_WIDTH = 80;
 static const size_t VGA_HEIGHT = 24;
-static uint16_t* TERMINAL_BUFFER = (uint16_t*) 0xB8000; 
+static uint16_t* TERMINAL_BUFFER = (uint16_t*) 0xB8000;
 
 static size_t current_terminal_row;
 static size_t current_terminal_column;
@@ -76,3 +76,30 @@ void terminal_write(const char* data) {
 		terminal_putchar(data[i]);
 }
 
+void terminal_write_int(int n) {
+	if (n < 0) {
+		terminal_putchar('-');
+		n = n * -1;
+	}
+
+	// Can shorten this step when we implement log
+	int num_digits = 0;
+	int tmp = n;
+	do {
+		num_digits++;
+		tmp = tmp / 10;
+	} while (tmp > 0);
+
+	do {
+		// Can shorten this step when we implement pow
+		int base = 1;
+		for (int i = 0; i < num_digits - 1; i++) {
+			base = base * 10;
+		}
+		char digit = (n / base);
+
+		terminal_putchar('0' + digit);
+		n = n - (digit * base);
+		num_digits--;
+	} while (num_digits > 0);
+}

--- a/src/io/terminal.h
+++ b/src/io/terminal.h
@@ -32,5 +32,6 @@ void terminal_set_color(uint8_t color);
 void terminal_put_entry_at(char c, uint8_t color, size_t x, size_t y);
 void terminal_put_char(char c);
 void terminal_write(const char* data);
+void terminal_write_int(int n);
 
 #endif  // TERMINAL_H


### PR DESCRIPTION
We can now debug by printing integers (e.g. addresses of objects, fields of structs, etc).