### PR TITLE
bootloader will have OS halt after returning from main

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -18,5 +18,4 @@ extern void kmain()
 	terminal_write("welcome to my first operating system!");
 	terminal_write("welcome to my first operating system!");
 	frame_buffer_move_cursor(81);
-	for(;;);
 }


### PR DESCRIPTION
# Summary
Kernel safely halts after returning from `kmain`, so there's no need to spin on the CPU.